### PR TITLE
Feature/178 handle repeating service level on fe move monitoring round to 2023

### DIFF
--- a/backend/source/production/main_config.py
+++ b/backend/source/production/main_config.py
@@ -24,7 +24,7 @@ TESTING_CASCADE_FILE = "cascade-654850917-v1.sqlite"
 MONITORING_FORM = False
 
 # to handle incorrect monitoring round data
-MONITORING_ROUND = 2018
+MONITORING_ROUND = 2023
 
 TMP_PATH = "./tmp"
 FAKE_STORAGE_PATH = f"{TMP_PATH}/fake-storage"


### PR DESCRIPTION
TODO / DONE

---

- #178 
- [x] Move monitoring round to 2023
- [x] Handle repeating service level on FE instead of set monitoring round to 2018 and not seed 2023 data into DB
- _Note: after merge to main, we need to reseed the test DB with data from Flow._

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205589525703504
  - https://app.asana.com/0/0/1205589525703499